### PR TITLE
Add support for WheelCollider

### DIFF
--- a/DebugStuff.cs
+++ b/DebugStuff.cs
@@ -467,6 +467,14 @@ namespace DebugStuff
                         DrawTools.DrawLocalMesh(mesh.transform, mesh.sharedMesh, XKCDColors.ElectricBlue);
                         Profiler.EndSample();
                     }
+
+                    if (baseCol is WheelCollider)
+                    {
+                        Profiler.BeginSample("WheelCollider");
+                        WheelCollider wheel = baseCol as WheelCollider;
+                        DrawTools.DrawCircle(wheel.transform.position, wheel.transform.right, XKCDColors.Fuchsia, wheel.radius);
+                        Profiler.EndSample();
+                    }
                 }
                 Profiler.EndSample();
             }


### PR DESCRIPTION
Display a circle in fuschia for `WheelCollider`s
![screenshot0](https://user-images.githubusercontent.com/28502722/56808474-7552a400-67e6-11e9-9301-82807e3e244b.png)

Somewhat annoyingly, doesn't show up in editor when plane of the circle is facing *precisely* left/right  
i.e. the exact orientation you'd normally expect to see them. I'm not exactly sure why.  
Works in any other orientation, e.g. just rotate whole vessel slightly and it will show up just fine.
![screenshot1](https://user-images.githubusercontent.com/28502722/56809013-b8614700-67e7-11e9-97b8-882abfed0451.png)

No issues encountered in flight.